### PR TITLE
Fix for inserting items via prepared queries

### DIFF
--- a/lib/postqueue/item/inserter.rb
+++ b/lib/postqueue/item/inserter.rb
@@ -4,8 +4,8 @@ module Postqueue
   #
   # Postqueue::Item inserter modules.
   #
-  # This source file provides multiple implementations to insert Postqueue::Items. 
-  # Which one will be used depends on the "extend XXXInserter" line below. 
+  # This source file provides multiple implementations to insert Postqueue::Items.
+  # Which one will be used depends on the "extend XXXInserter" line below.
   class Item < ActiveRecord::Base
     module ActiveRecordInserter
       def insert_item(op:, entity_id:)

--- a/lib/postqueue/item/inserter.rb
+++ b/lib/postqueue/item/inserter.rb
@@ -31,17 +31,17 @@ module Postqueue
       def prepared_inserter_statement
         @prepared_inserter_statements ||= {}
 
-        # a prepared connection is PER DATABASE connection. It is not shared across
+        # a prepared connection is PER DATABASE CONNECTION. It is not shared across
         # connections, and it is not per thread, since a Thread might use different
         # connections during its lifetime.
-        connection_id = connection.raw_connection.object_id
-        @prepared_inserter_statements[connection_id] ||= create_prepared_inserter_statement
+        raw_connection = connection.raw_connection
+        @prepared_inserter_statements[raw_connection.object_id] ||= create_prepared_inserter_statement(raw_connection)
       end
 
       # prepares the INSERT statement, and returns its name
-      def create_prepared_inserter_statement
-        name = "postqueue-insert-#{table_name}"
-        connection.raw_connection.prepare(name, insert_sql)
+      def create_prepared_inserter_statement(raw_connection)
+        name = "postqueue-insert-#{table_name}-#{raw_connection.object_id}"
+        raw_connection.prepare(name, insert_sql)
         name
       end
 

--- a/lib/postqueue/item/inserter.rb
+++ b/lib/postqueue/item/inserter.rb
@@ -2,7 +2,10 @@ require "active_record"
 
 module Postqueue
   #
-  # An item class.
+  # Postqueue::Item inserter modules.
+  #
+  # This source file provides multiple implementations to insert Postqueue::Items. 
+  # Which one will be used depends on the "extend XXXInserter" line below. 
   class Item < ActiveRecord::Base
     module ActiveRecordInserter
       def insert_item(op:, entity_id:)
@@ -11,12 +14,35 @@ module Postqueue
     end
 
     module RawInserter
+      def insert_sql
+        "INSERT INTO #{table_name}(op, entity_id) VALUES($1, $2)"
+      end
+
+      def insert_item(op:, entity_id:)
+        connection.raw_connection.exec_params(insert_sql, [op, entity_id])
+      end
+    end
+
+    module PreparedRawInserter
+      def insert_sql
+        "INSERT INTO #{table_name}(op, entity_id) VALUES($1, $2)"
+      end
+
       def prepared_inserter_statement
-        @prepared_inserter_statement ||= begin
-          name = "postqueue-insert-{table_name}-#{Thread.current.object_id}"
-          connection.raw_connection.prepare(name, "INSERT INTO #{table_name}(op, entity_id) VALUES($1, $2)")
-          name
-        end
+        @prepared_inserter_statements ||= {}
+
+        # a prepared connection is PER DATABASE connection. It is not shared across
+        # connections, and it is not per thread, since a Thread might use different
+        # connections during its lifetime.
+        connection_id = connection.raw_connection.object_id
+        @prepared_inserter_statements[connection_id] ||= create_prepared_inserter_statement
+      end
+
+      # prepares the INSERT statement, and returns its name
+      def create_prepared_inserter_statement
+        name = "postqueue-insert-#{table_name}"
+        connection.raw_connection.prepare(name, insert_sql)
+        name
       end
 
       def insert_item(op:, entity_id:)
@@ -24,7 +50,8 @@ module Postqueue
       end
     end
 
-    # extend RawInserter
-    extend ActiveRecordInserter
+    # extend ActiveRecordInserter   # 600µs per item
+    extend RawInserter              # 100µs per item
+    #extend PreparedRawInserter     # 50µs per item
   end
 end

--- a/lib/postqueue/item/inserter.rb
+++ b/lib/postqueue/item/inserter.rb
@@ -28,13 +28,12 @@ module Postqueue
         "INSERT INTO #{table_name}(op, entity_id) VALUES($1, $2)"
       end
 
-      def prepared_inserter_statement
+      def prepared_inserter_statement(raw_connection)
         @prepared_inserter_statements ||= {}
 
         # a prepared connection is PER DATABASE CONNECTION. It is not shared across
         # connections, and it is not per thread, since a Thread might use different
         # connections during its lifetime.
-        raw_connection = connection.raw_connection
         @prepared_inserter_statements[raw_connection.object_id] ||= create_prepared_inserter_statement(raw_connection)
       end
 
@@ -46,12 +45,14 @@ module Postqueue
       end
 
       def insert_item(op:, entity_id:)
-        connection.raw_connection.exec_prepared(prepared_inserter_statement, [op, entity_id])
+        raw_connection = connection.raw_connection
+        statement_name = prepared_inserter_statement(raw_connection)
+        raw_connection.exec_prepared(statement_name, [op, entity_id])
       end
     end
 
     # extend ActiveRecordInserter   # 600µs per item
     extend RawInserter              # 100µs per item
-    #extend PreparedRawInserter     # 50µs per item
+    # extend PreparedRawInserter    # 50µs per item
   end
 end


### PR DESCRIPTION
This commit hopefully fixes inserting via prepared queries. The error
seems to have been that a prepared query was used on connections, that
did not prepare the query.

This commit also adds a raw connection non-prepared queries as well, which is
activated by default.